### PR TITLE
Use plain `make install`

### DIFF
--- a/fluidkeys-formula-template.rb
+++ b/fluidkeys-formula-template.rb
@@ -8,7 +8,7 @@ class Fluidkeys < Formula
   depends_on "dep" => :build
 
   def install
-    system "make", "homebrew_install"
+    system "make", "install"
   end
 
   test do


### PR DESCRIPTION
not `homebrew_install`, which is now a deprecated alias:

https://github.com/fluidkeys/fluidkeys/commit/b21a79b9