### PR TITLE
Revert "Depend on dep"

### DIFF
--- a/fluidkeys-formula-template.rb
+++ b/fluidkeys-formula-template.rb
@@ -5,7 +5,6 @@ class Fluidkeys < Formula
   version "{{version}}"
   sha256 "{{tarball_sha256}}"
   depends_on "go" => :build
-  depends_on "dep" => :build
 
   def install
     system "make", "homebrew_install"


### PR DESCRIPTION
This reverts commit 34ef4d889c14ef465de1e282ca5e307fef5207fc.

That was a bit hasty on my part. `make compile` should not mess around
with dependencies, which are committed into `vendor/`

Related:

* https://github.com/fluidkeys/fluidkeys/pull/37/commits