### PR TITLE
Move the tarball url to download.fluidkeys.com

### DIFF
--- a/script/create_formula
+++ b/script/create_formula
@@ -11,7 +11,7 @@ print_tag_and_version() {
 }
 
 set_tarball_url() {
-  TARBALL_URL="https://github.com/fluidkeys/fluidkeys-cli/archive/${TAG}.tar.gz"
+  TARBALL_URL="https://download.fluidkeys.com/source/${TAG}.tar.gz"
   # ESCAPED_TARBALL_URL="${TARBALL_URL//\//\\/}"
 }
 


### PR DESCRIPTION
This will allow us to track homebrew installs