### PR TITLE
Update homebrew formula template for GOPATH

### DIFF
--- a/fluidkeys-formula-template.rb
+++ b/fluidkeys-formula-template.rb
@@ -7,7 +7,16 @@ class Fluidkeys < Formula
   depends_on "go" => :build
 
   def install
-    system "make", "install"
+    ENV["GOPATH"] = buildpath/"gopath"
+    dir = buildpath/"gopath/src/github.com/fluidkeys/fluidkeys"
+    dir.install buildpath.children
+
+    cd dir do
+      system "make"
+      bin.install "build/bin/fk"
+
+      prefix.install_metafiles
+    end
   end
 
   test do


### PR DESCRIPTION
`make install` in github.com/fluidkeys/fluidkeys no longer fights
against the "repo must be cloned inside $GOPATH" go insistence.

As a result, the formula no longer worked.

This needs testing, but it follows the pattern I've seen in a load of
other Go projects in homebrew.